### PR TITLE
add zabbix-sender to debian reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ On client:
     # Install the following packages
     
     # Debian/Ubuntu
-    apt-get install pflogsumm bc
+    apt install pflogsumm bc zabbix-sender
     
     # RHEL/Centos
     yum install postfix-perl-scripts bc


### PR DESCRIPTION
add missing required dependency, that is not necessarily installed on a zabbix client